### PR TITLE
Encode dashboard tab in URL

### DIFF
--- a/orb-console/src/components/Dashboard.tsx
+++ b/orb-console/src/components/Dashboard.tsx
@@ -55,8 +55,8 @@ export default function Dashboard() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const searchParamsString = searchParams.toString();
-  const tabParam = searchParams.get("tab");
+  const searchParamsString = searchParams?.toString() ?? "";
+  const tabParam = searchParams?.get("tab") ?? null;
 
   //----------------------------------------------------------------------------
   const [activeTab, setActiveTabState] = useState<Tab>(() =>
@@ -102,7 +102,9 @@ export default function Dashboard() {
       const queryString = params.toString();
       const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
 
-      router.replace(newUrl, { scroll: false });
+      if (newUrl) {
+        router.replace(newUrl, { scroll: false });
+      }
     }
   }, [tabParam, searchParamsString, pathname, router]);
 
@@ -125,7 +127,9 @@ export default function Dashboard() {
       const queryString = params.toString();
       const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
 
-      router.push(newUrl, { scroll: false });
+      if (newUrl) {
+        router.push(newUrl, { scroll: false });
+      }
     },
     [pathname, router, searchParamsString, tabParam],
   );

--- a/orb-console/src/components/Dashboard.tsx
+++ b/orb-console/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@
 // import Image from "next/image";
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { Footer } from "@/components/Footer";
 import { useDashboardData } from "@/hooks/useDashboardData";
@@ -29,6 +30,19 @@ import colors from "tailwindcss/colors";
 import { UserMenuDropdown } from "@/components/UserMenuDropdown";
 import { getPackageVulnerabilityScore } from "@/utils/vulnerabilityScore";
 
+const DEFAULT_TAB: Tab = "packages";
+
+const isValidTab = (value: string | null): value is Tab =>
+  value === "packages" ||
+  value === "systems" ||
+  value === "allow" ||
+  value === "vulns" ||
+  value === "tenant" ||
+  value === "account";
+
+const getTabFromParam = (param: string | null): Tab =>
+  isValidTab(param) ? param : DEFAULT_TAB;
+
 //------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
@@ -38,8 +52,16 @@ export default function Dashboard() {
 
   const { data: session, status } = useSession();
 
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const tabParam = searchParams.get("tab");
+
   //----------------------------------------------------------------------------
-  const [activeTab, setActiveTab] = useState<Tab>("packages");
+  const [activeTab, setActiveTabState] = useState<Tab>(() =>
+    getTabFromParam(tabParam),
+  );
   const [selectedTenantId, setSelectedTenantId] = useState<number | null>(null);
   const [selectedSystemId, setSelectedSystemId] = useState<number | null>(null);
   const [highlightedSystemTagId, setHighlightedSystemTagId] = useState<
@@ -66,6 +88,46 @@ export default function Dashboard() {
   const [lastAuditTime, setLastAuditTime] = useState<number | null>(null);
   const [lastPackageDataHash, setLastPackageDataHash] = useState<string | null>(
     null,
+  );
+
+  //----------------------------------------------------------------------------
+
+  useEffect(() => {
+    const tabFromUrl = getTabFromParam(tabParam);
+    setActiveTabState((prev) => (prev === tabFromUrl ? prev : tabFromUrl));
+
+    if (tabParam && !isValidTab(tabParam)) {
+      const params = new URLSearchParams(searchParamsString);
+      params.delete("tab");
+      const queryString = params.toString();
+      const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
+
+      router.replace(newUrl, { scroll: false });
+    }
+  }, [tabParam, searchParamsString, pathname, router]);
+
+  const setActiveTab = useCallback(
+    (tab: Tab) => {
+      setActiveTabState((prev) => (prev === tab ? prev : tab));
+
+      const currentTab = getTabFromParam(tabParam);
+      if (currentTab === tab) {
+        return;
+      }
+
+      const params = new URLSearchParams(searchParamsString);
+      if (tab === DEFAULT_TAB) {
+        params.delete("tab");
+      } else {
+        params.set("tab", tab);
+      }
+
+      const queryString = params.toString();
+      const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
+
+      router.push(newUrl, { scroll: false });
+    },
+    [pathname, router, searchParamsString, tabParam],
   );
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- synchronize the dashboard's active tab with the `tab` search parameter and validate incoming values
- push updates to the URL when tabs change so browser navigation mirrors tab selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccceaff7308332b955e05ad024831e